### PR TITLE
fix: Fix npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint --config .eslintrc.yaml .",
     "get-version": "echo $npm_package_version"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/asyncapi/avro-schema-parser.git"


### PR DESCRIPTION
Release is failing because package.json is missing `publishConfig` property.