### PR TITLE
chore: replace @github-actions[bot] with @asyncapi-bot-eve

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
-* @derberg @fmvilas @M3lkior @dalelane @github-actions[bot]
+* @derberg @fmvilas @M3lkior @dalelane @asyncapi-bot-eve


### PR DESCRIPTION
the CODEOWNERS file where @github-actions[bot] was being added as Code Owner. This is not currently possible, as we noticed recently thanks to GH which added lining to the CODEOWNERS file.
Instead, @asyncapi-bot-eve user has been created for this purpose and now is being added into the CODEOWNERS file.

Refer asyncapi/community#275
